### PR TITLE
Ensure routes are matchable

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -7,8 +7,10 @@ export const NO_MATCH = 'NO_MATCH';
 
 export function connectToStore(store, routes) {
 
-  if (typeof routes.length === 'undefined') {
-    routes = Object.keys(routes).map((key) => routes[key]);
+  if (!Array.isArray(routes)) {
+    routes = Object.keys(routes)
+      .map((key) => routes[key])
+      .filter(r => typeof r === 'string' || r.exec);
   }
 
   const history = createHistory();


### PR DESCRIPTION
Some context here: this ensures given routes are matchable (`string` or `regexp`).

This is particularly useful in situation like using babel with `loose:[es6.module]` where `__esModule:true` is injected to imported modules.